### PR TITLE
Adds an initial TCK project

### DIFF
--- a/src/backend/core/src/main/resources/reference.conf
+++ b/src/backend/core/src/main/resources/reference.conf
@@ -2,8 +2,10 @@ stateful-serverless {
     dev-mode-enabled = false
     http-interface = "0.0.0.0"
     http-port = 9000
-    user-function-interface = "localhost"
+    http-port = ${?HTTP_PORT}
+    user-function-interface = "127.0.0.1"
     user-function-port = 8080
+    user-function-port = ${?USER_FUNCTION_PORT}
     relay-timeout = 1m
     relay-buffer-size = 100
     passivation-timeout = 30s // Keep short for testing purposes

--- a/src/backend/core/src/main/scala/com/lightbend/statefulserverless/ServerManager.scala
+++ b/src/backend/core/src/main/scala/com/lightbend/statefulserverless/ServerManager.scala
@@ -149,6 +149,6 @@ class ServerManager(config: ServerManager.Configuration)(implicit mat: Materiali
     super.postStop()
     client.close()
     log.debug("shutting down")
-    // TODO do we system.terminate() here?
+    system.terminate()
   }
 }

--- a/src/build.sbt
+++ b/src/build.sbt
@@ -38,7 +38,7 @@ headerSources in Compile ++= {
 }
 
 lazy val root = (project in file("."))
-  .aggregate(`backend-core`, `backend-cassandra`, `akka-client`, operator)
+  .aggregate(`backend-core`, `backend-cassandra`, `akka-client`, operator, `tck`)
   .settings(common)
 
 def dockerSettings: Seq[Setting[_]] = Seq(
@@ -54,14 +54,14 @@ lazy val `backend-core` = (project in file("backend/core"))
     common,
     name := "stateful-serverless-backend-core",
     libraryDependencies ++= Seq(
-      "com.typesafe.akka" %% "akka-persistence" % AkkaVersion,
-      "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
-      "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
-      "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
-      "com.typesafe.akka" %% "akka-cluster-sharding" % AkkaVersion,
+      "com.typesafe.akka"             %% "akka-persistence"                  % AkkaVersion,
+      "com.typesafe.akka"             %% "akka-stream"                       % AkkaVersion,
+      "com.typesafe.akka"             %% "akka-http"                         % AkkaHttpVersion,
+      "com.typesafe.akka"             %% "akka-http-spray-json"              % AkkaHttpVersion,
+      "com.typesafe.akka"             %% "akka-cluster-sharding"             % AkkaVersion,
       "com.lightbend.akka.management" %% "akka-management-cluster-bootstrap" % AkkaManagementVersion,
-      "com.lightbend.akka.discovery" %% "akka-discovery-kubernetes-api" % AkkaManagementVersion,
-      "com.google.protobuf" % "protobuf-java" % "3.5.1" % "protobuf" // TODO remove this, see: https://github.com/akka/akka-grpc/issues/565
+      "com.lightbend.akka.discovery"  %% "akka-discovery-kubernetes-api"     % AkkaManagementVersion,
+      "com.google.protobuf"            % "protobuf-java"                     % "3.5.1" % "protobuf" // TODO remove this, see: https://github.com/akka/akka-grpc/issues/565
     ),
 
     // Akka gRPC adds all protobuf files from the classpath to this, which we don't want because it includes
@@ -86,7 +86,7 @@ lazy val `backend-cassandra` = (project in file("backend/cassandra"))
     common,
     name := "stateful-serverless-backend-cassandra",
     libraryDependencies ++= Seq(
-      "com.typesafe.akka" %% "akka-persistence-cassandra" % AkkaPersistenceCassandraVersion,
+      "com.typesafe.akka" %% "akka-persistence-cassandra"          % AkkaPersistenceCassandraVersion,
       "com.typesafe.akka" %% "akka-persistence-cassandra-launcher" % AkkaPersistenceCassandraVersion % Test
     ),
     dockerSettings,
@@ -127,11 +127,11 @@ lazy val `akka-client` = (project in file("samples/akka-js-shopping-cart-client"
     fork in run := true,
 
     libraryDependencies ++= Seq(
-      "com.typesafe.akka" %% "akka-persistence" % AkkaVersion,
-      "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
-      "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
-      "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
-      "com.google.protobuf" % "protobuf-java" % "3.5.1" % "protobuf" // TODO remove this, see: https://github.com/akka/akka-grpc/issues/565
+      "com.typesafe.akka"  %% "akka-persistence"     % AkkaVersion,
+      "com.typesafe.akka"  %% "akka-stream"          % AkkaVersion,
+      "com.typesafe.akka"  %% "akka-http"            % AkkaHttpVersion,
+      "com.typesafe.akka"  %% "akka-http-spray-json" % AkkaHttpVersion,
+      "com.google.protobuf" % "protobuf-java"        % "3.5.1" % "protobuf" // TODO remove this, see: https://github.com/akka/akka-grpc/issues/565
     ),
 
     target in copyShoppingCartProtos := target.value / "js-shopping-cart-protos",
@@ -154,7 +154,44 @@ lazy val `akka-client` = (project in file("samples/akka-js-shopping-cart-client"
       copyShoppingCartProtos.value
       (PB.unpackDependencies in Compile).value
     }
+  )
 
+val copyProtocolProtosToTCK = taskKey[File]("Copy the protocol files to the tck")
+
+lazy val `tck` = (project in file("tck"))
+  .enablePlugins(AkkaGrpcPlugin)
+  .dependsOn(`backend-core`) // For the protocol
+  .dependsOn(`akka-client`) // For the shopping cart
+  .settings(
+    name := "tck",
+
+    fork in test := true,
+
+    parallelExecution in Test := false,
+
+    libraryDependencies ++= Seq(
+      "com.typesafe.akka"  %% "akka-stream"          % AkkaVersion,
+      "com.typesafe.akka"  %% "akka-http"            % AkkaHttpVersion,
+      "com.typesafe.akka"  %% "akka-http-spray-json" % AkkaHttpVersion,
+      "com.google.protobuf" % "protobuf-java"        % "3.5.1" % "protobuf", // TODO remove this, see: https://github.com/akka/akka-grpc/issues/565
+      "org.scalatest"       % "scalatest_2.12"       % "3.0.5" % Test,
+      "com.typesafe.akka"  %% "akka-testkit"         % AkkaVersion % Test
+    ),
+
+    target in copyProtocolProtosToTCK := target.value / "backend-protos",
+    copyProtocolProtosToTCK := {
+      val toDir = (target in copyProtocolProtosToTCK).value
+      val fromDir = baseDirectory.value.getParentFile / "backend" / "core" / "src" / "main" / "proto"
+      val toSync = (fromDir * "*.proto").get.map(file => file -> toDir / file.getName)
+      Sync.sync(streams.value.cacheStoreFactory.make(copyProtocolProtosToTCK.toString()))(toSync)
+      toDir
+    },
+
+    PB.protoSources in Compile += (target in copyProtocolProtosToTCK).value,
+    (PB.unpackDependencies in Compile) := {
+      copyProtocolProtosToTCK.value
+      (PB.unpackDependencies in Compile).value
+    }
   )
 
 def doCompileK8sDescriptors(dir: File, target: File, registry: String, username: String, version: String): File = {

--- a/src/node-support/package-lock.json
+++ b/src/node-support/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "stateful-serverless-event-sourcing",
-  "version": "0.2.0",
+  "version": "0.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/samples/akka-js-shopping-cart-client/src/main/scala/com/example/Client.scala
+++ b/src/samples/akka-js-shopping-cart-client/src/main/scala/com/example/Client.scala
@@ -55,11 +55,11 @@ object Client {
   * @param hostname
   * @param port
   */
-class Client(hostname: String, port: Int) {
-
-  private implicit val system = ActorSystem()
-  private implicit val mat = ActorMaterializer()
-  import system.dispatcher
+class Client(hostname: String, port: Int, sys: ActorSystem) {
+  def this(hostname: String, port: Int) = this(hostname, port, ActorSystem())
+  private implicit val system = sys
+  private implicit val materializer = ActorMaterializer()
+  import sys.dispatcher
 
   val service = ShoppingCartClient(GrpcClientSettings.connectToServiceAt(hostname, port).withTls(false))
 

--- a/src/samples/js-shopping-cart/shoppingcart.js
+++ b/src/samples/js-shopping-cart/shoppingcart.js
@@ -80,17 +80,23 @@ entity.setBehavior(cart => {
  * Handler for add item commands.
  */
 function addItem(addItem, cart, ctx) {
+  // Validation:
+  // Make sure that it is not possible to add negative quantities
+  if (addItem.quantity < 1) {
+    ctx.fail("Cannot add negative quantity to item " + addItem.productId);
+  } else {
   // Create the event.
-  const itemAdded = ItemAdded.create({
-    item: {
-      productId: addItem.productId,
-      name: addItem.name,
-      quantity: addItem.quantity
-    }
-  });
-  // Emit the event.
-  ctx.emit(itemAdded);
-  return {};
+    const itemAdded = ItemAdded.create({
+      item: {
+        productId: addItem.productId,
+        name: addItem.name,
+        quantity: addItem.quantity
+      }
+    });
+    // Emit the event.
+    ctx.emit(itemAdded);
+    return {};
+  }
 }
 
 /**

--- a/src/tck/src/test/resources/reference.conf
+++ b/src/tck/src/test/resources/reference.conf
@@ -1,0 +1,29 @@
+stateful-serverless-tck {
+  tck {
+    hostname = "127.0.0.1"
+    hostname = ${?HOST}
+    port = 8090
+  }
+
+  backend {
+    hostname = "127.0.0.1"
+    hostname = ${?HOST}
+    port = 9000
+    directory = ${user.dir}
+    command = ["sbt", "backend-core/run"]
+    env-vars {
+      USER_FUNCTION_PORT = "8090"
+    }
+  }
+
+  frontend {
+    hostname = "127.0.0.1"
+    hostname = ${?HOST}
+    port = 8080
+    directory = ${user.dir}/samples/js-shopping-cart
+    command = ["node", "index.js"]
+    env-vars {
+      DEBUG = "stateserv-event-sourcing"
+    }
+  }
+}

--- a/src/tck/src/test/resources/reference.conf
+++ b/src/tck/src/test/resources/reference.conf
@@ -10,7 +10,7 @@ stateful-serverless-tck {
     hostname = ${?HOST}
     port = 9000
     directory = ${user.dir}
-    command = ["sbt", "backend-core/run"]
+    command = ["java", "-Xmx512M", "-Xms128M", "-Dconfig.resource=in-memory.conf", "-Dstateful-serverless.dev-mode-enabled=true", "-jar", "backend/core/target/scala-2.12/akka-backend.jar"]
     env-vars {
       USER_FUNCTION_PORT = "8090"
     }

--- a/src/tck/src/test/scala/com/lightbend/statefulserverless/tck/StatefulServerlessTCK.scala
+++ b/src/tck/src/test/scala/com/lightbend/statefulserverless/tck/StatefulServerlessTCK.scala
@@ -1,0 +1,310 @@
+package com.lightbend.statefulserverless.tck
+
+import akka.NotUsed
+import akka.actor.{ActorSystem, Scheduler}
+import akka.stream.{Materializer, ActorMaterializer}
+import akka.stream.scaladsl.{Source, Sink}
+import akka.pattern.after
+
+import akka.grpc.GrpcClientSettings
+
+import org.scalatest._
+import com.typesafe.config.Config
+
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.duration._
+import scala.collection.JavaConverters._
+import scala.util.{Success, Failure, Try}
+
+import java.util.{Map => JMap}
+import java.util.concurrent.TimeUnit
+import java.lang.{ProcessBuilder, Process}
+import java.io.File
+
+import akka.http.scaladsl.{Http, HttpConnectionContext, UseHttp2}
+import akka.http.scaladsl.Http.ServerBinding
+
+import com.lightbend.statefulserverless.grpc._
+import com.example.shoppingcart._
+
+import akka.testkit.{ TestActors, TestKit, TestProbe }
+
+import com.google.protobuf.empty.Empty
+
+object StatefulServerlessTCK {
+  private[this] final val BACKEND   = "stateful-serverless-tck.backend"
+  private[this] final val FRONTEND  = "stateful-serverless-tck.frontend"
+  private[this] final val TCK       = "stateful-serverless-tck.tck"
+  private[this] final val HOSTNAME  = "hostname"
+  private[this] final val PORT      = "port"
+
+  final case class ProcSpec private(
+    hostname: String,
+    port: Int,
+    directory: File,
+    command: Array[String],
+    envVars: JMap[String, Object]
+  ) {
+    def this(config: Config) = this(
+      hostname   =          config.getString(HOSTNAME ),
+      port       =          config.getInt(   PORT     ),
+      directory  = new File(config.getString("directory")),
+      command    =          config.getList(  "command").unwrapped.toArray.map(_.toString),
+      envVars    =          config.getConfig("env-vars").root.unwrapped,
+    )
+    def validate(): Unit = {
+      require(directory.exists, s"Configured directory (${directory}) does not exist")
+      require(directory.isDirectory, s"Configured directory (${directory}) is not a directory")
+    }
+  }
+  final case class Configuration private(
+    backend: ProcSpec,
+    frontend: ProcSpec,
+    tckHostname: String,
+    tckPort: Int) {
+    def this(config: Config) = this(
+      backend     = new ProcSpec(config.getConfig(BACKEND)),
+      frontend    = new ProcSpec(config.getConfig(FRONTEND)),
+      tckHostname = config.getString(TCK + "." + HOSTNAME),
+      tckPort     = config.getInt(   TCK + "." + PORT)
+    )
+
+    def validate(): Unit = {
+      backend.validate()
+      frontend.validate()
+      // FIXME implement
+    }
+  }
+
+  final val noWait = 0.seconds
+
+  // FIXME add interception to enable asserting exchanges
+  final class EntityInterceptor(val client: EntityClient, val fromBackend: TestProbe, val fromFrontend: TestProbe)(implicit ec: ExecutionContext) extends Entity {
+
+    private final val fromBackendInterceptor = Sink.actorRef[AnyRef](fromBackend.ref, "BACKEND_TERMINATED")
+    private final val fromFrontendInterceptor = Sink.actorRef[AnyRef](fromFrontend.ref, "FRONTEND_TERMINATED")
+
+    override def handle(in: Source[EntityStreamIn, NotUsed]): Source[EntityStreamOut, NotUsed] =
+      client.handle(in.alsoTo(fromBackendInterceptor)).alsoTo(fromFrontendInterceptor)
+
+    override def ready(in: Empty): Future[EntitySpec] = {
+      fromBackend.ref ! in
+      client.ready(in).andThen {
+        case Success(es) => fromFrontend.ref ! es
+        case Failure(f)  => fromFrontend.ref ! f
+      }
+    }
+  }
+
+  def attempt[T](op: => Future[T], delay: FiniteDuration, retries: Int)(implicit ec: ExecutionContext, s: Scheduler): Future[T] =
+    Future.unit.flatMap(_ => op) recoverWith { case _ if retries > 0 => after(delay, s)(attempt(op, delay, retries - 1)) }
+}
+
+class StatefulServerlessTCK extends AsyncWordSpec with MustMatchers with BeforeAndAfterAll {
+  import StatefulServerlessTCK._
+            private[this] final val system                               = ActorSystem("StatefulServerlessTCK")
+            private[this] final val mat                                  = ActorMaterializer()(system)
+            private[this] final val config                               = new Configuration(system.settings.config)
+            private[this] final val fromBackend                          = TestProbe("fromBackend")(system)
+            private[this] final val fromFrontend                         = TestProbe("fromFrontend")(system)
+  @volatile private[this] final var shoppingClient:  ShoppingCartClient  = _
+  @volatile private[this] final var entityClient:    EntityClient        = _
+  @volatile private[this] final var backendProcess:  Process             = _
+  @volatile private[this] final var frontendProcess: Process             = _
+  @volatile private[this] final var tckProxy:        ServerBinding       = _
+
+  final implicit override def executionContext = system match {
+    case null => super.executionContext
+    case some => some.dispatcher
+  }
+
+  def process(ps: ProcSpec): ProcessBuilder = {
+    val pb =
+      new ProcessBuilder(ps.command:_*).
+      inheritIO().
+      directory(ps.directory)
+
+    val env = pb.environment
+
+    ps.envVars.entrySet.forEach { e =>
+      e.getValue match {
+        case value: String => env.put(e.getKey, value)
+        case _ => // Ignore
+      }
+    }
+    pb
+  }
+
+  def buildTCKProxy(client: EntityClient, implementation: Entity): Future[ServerBinding] = {
+    implicit val s = system
+    implicit val m = mat
+    Http().bindAndHandleAsync(
+        handler = EntityHandler(implementation),
+        interface = config.tckHostname,
+        port = config.tckPort,
+        connectionContext = HttpConnectionContext(http2 = UseHttp2.Always)
+      )
+    }
+
+  override def beforeAll(): Unit = {
+
+    config.validate()
+
+    val fp = process(config.frontend).
+               start()
+
+    require(fp.isAlive())
+
+    frontendProcess = fp
+
+    val ec = EntityClient(GrpcClientSettings.connectToServiceAt(config.frontend.hostname, config.frontend.port)(system).withTls(false))(mat, mat.executionContext)
+
+    entityClient = ec
+
+    val tp = Await.result(buildTCKProxy(ec, new EntityInterceptor(ec, fromBackend, fromFrontend)(system.dispatcher)), 10.seconds)
+
+    tckProxy = tp
+
+    val bp = process(config.backend).
+              start()
+
+    require(bp.isAlive())
+
+    backendProcess = bp
+
+    val sc = ShoppingCartClient(GrpcClientSettings.connectToServiceAt(config.backend.hostname, config.backend.port)(system).withTls(false))(mat, mat.executionContext)
+
+    shoppingClient = sc
+  }
+
+  override final def afterAll(): Unit = {
+    def destroy(p: Process): Unit = while(p.isAlive) {
+      p.destroy()
+      p.waitFor(5, TimeUnit.SECONDS) || {
+        p.destroyForcibly()
+        true // todo revisit this
+      }// todo make configurable
+    }
+    try
+      Option(shoppingClient).foreach(c => Await.result(c.close(), 10.seconds))
+    finally
+      try Option(backendProcess).foreach(destroy)
+        finally Option(entityClient).foreach(c => Await.result(c.close(), 10.seconds))
+          try Option(frontendProcess).foreach(destroy)
+            finally Await.ready(tckProxy.unbind().transformWith(_ => system.terminate())(system.dispatcher), 30.seconds)
+  }
+
+  final def fromFrontend_expectEntitySpec(within: FiniteDuration): EntitySpec = {
+    val spec = fromFrontend.expectMsgType[EntitySpec](within)
+    spec.proto must be(defined)
+    spec.serviceName must not be empty
+    spec.persistenceId must not be empty
+    spec
+  }
+
+  final def fromBackend_expectInit(within: FiniteDuration): Init = {
+    val init = fromBackend.expectMsgType[EntityStreamIn](noWait)
+    init must not be(null)
+    init.message must be('init)
+    init.message.init must be(defined)
+    val i = init.message.init.get
+    //FIXME validate
+    //i.entityId
+    //i.snapshot
+    i
+  }
+
+  final def fromBackend_expectCommand(within: FiniteDuration): Command = {
+    val command = fromBackend.expectMsgType[EntityStreamIn](noWait)
+    command must not be(null)  // FIXME validate Command
+    command.message must be('command)
+    command.message.command must be(defined)
+    val c = command.message.command.get
+    //FIXME validate
+    //c.entityId
+    //c.id
+    //c.payload
+    c
+  }
+
+  final def fromFrontend_expectReply(within: FiniteDuration): Reply = {
+    val reply = fromFrontend.expectMsgType[EntityStreamOut](noWait)
+    reply must not be(null)
+    reply.message must be('reply)
+    reply.message.reply must be(defined)
+    val r = reply.message.reply.get
+    //FIXME validate
+    //r.commandId
+    //r.payload
+    //r.events
+    //r.snapshot
+    r
+  }
+
+  "The TCK" must {
+    implicit val scheduler = system.scheduler
+
+    "verify that the user function process responds" in {
+      attempt(entityClient.ready(Empty()), 4.seconds, 10) map { spec =>
+        spec.proto must be(defined)
+        spec.serviceName must not be empty
+        spec.persistenceId must not be empty
+      }
+    }
+
+    "verify that an initial GetShoppingCart request succeeds" in {
+      val userId = "testuser:1"
+      attempt(shoppingClient.getCart(GetShoppingCart(userId)), 4.seconds, 10) map {
+        cart =>
+          // Interaction test
+          val _     = fromBackend.expectMsg(Empty())
+
+          val spec  = fromFrontend_expectEntitySpec(noWait)
+
+          val init  = fromBackend_expectInit(noWait)
+
+          val cmd   = fromBackend_expectCommand(noWait)
+
+          val reply = fromFrontend_expectReply(noWait)
+
+          fromBackend.expectNoMsg(noWait)
+          fromFrontend.expectNoMsg(noWait)
+          
+          // Semantical test
+          cart must not be(null)
+          cart.items must be(empty)
+
+          cmd.id must be(reply.commandId)
+      }
+    }
+
+    "verify that items can be added to a shopping cart" in {
+      val userId       = "testuser:2"
+      val productId1   = "testproduct:1"
+      val productId2   = "testproduct:2"
+      val productName1 = "Test Product 1"
+      val productName2 = "Test Product 2"
+      for {
+        cart  <- shoppingClient.getCart(GetShoppingCart(userId))
+        res1  <- shoppingClient.addItem(AddLineItem(userId, productId1, productName1, 1))
+        res2  <- shoppingClient.addItem(AddLineItem(userId, productId2, productName2, 2))
+        res3  <- shoppingClient.addItem(AddLineItem(userId, productId1, productName1, 11))
+        res4  <- shoppingClient.addItem(AddLineItem(userId, productId2, productName2, 5))
+        cart1 <- shoppingClient.getCart(GetShoppingCart(userId))
+      } yield {
+        //FIXME interaction test
+
+        //Semantical test
+        cart must not be(null)
+        cart.items must be(empty)
+        res1 must be(Empty())
+        res2 must be(Empty())
+        res3 must be(Empty())
+        res4 must be(Empty())
+        cart1 must not be(null)
+        cart1.items must not be(empty)
+        cart1.items.toSet must be(Set(LineItem(productId1, productName1, 12), LineItem(productId2, productName2, 7)))
+      }
+    }
+  }
+}


### PR DESCRIPTION
Alright, so now we have the capability to start backends and frontends and verify both interactions and semantics—of course lots of tests yet to be written, but now we can add and run the tests as normal.

running the `test` task in the build will also run the tck (the default configuration is to run the akka backend with the js example frontend but is of course configurable).

TODO is to launch the akka backend without running it through sbt, I guess we'd have to come up with some form of alternative packaging, but it might be something worthwhile as we add Knative Build integration?